### PR TITLE
#16 update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@ This will have postgres and adminer running for the backend
 docker-compose up -d
 ```
 
-### Start Apollo Server(backend)
-
-```sh
-pnpm backend
-```
-
-This will run apollo graphql playground at port 5000
-
 ### Test Prisma(backend)
 
 ```sh
@@ -48,6 +40,15 @@ pnpm generate
 pnpm migrate
 ```
 
+### Start Apollo Server(backend)
+
+```sh
+pnpm backend
+```
+
+This will run apollo graphql playground at port 5000
+
+
 you can then use adminer at port 8080, or run
 
 ```sh
@@ -55,3 +56,6 @@ pnpm studio
 ```
 
 to open up prisma studio to check whether the data is properly saved
+
+### Problems may occur
+- kill the port being stucked: `sudo kill -9 $(sudo lsof -t -i:port)`. If you want to kill port 8080, type: `sudo kill -9 $(sudo lsof -t -i:8080)`


### PR DESCRIPTION
Switching the order of Start Apollo Server(backend) and Test Prisma(backend) and adding a part `Problems may occur` to record the problems during setting up. 